### PR TITLE
fix: support the new Xcode 16 location for profiles

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -223,7 +223,8 @@ describe("provision", function () {
   it("looks at the default path", () => {
     let fs = {
       readdirSync(dir: string): string[] {
-        assert(dir.endsWith("Library/MobileDevice/Provisioning Profiles/"));
+        assert(dir.endsWith("Library/MobileDevice/Provisioning Profiles/") ||
+               dir.endsWith("Library/Developer/Xcode/UserData/Provisioning Profiles"));
         return [];
       },
       readFileSync(path: string): string {
@@ -234,7 +235,7 @@ describe("provision", function () {
     fs.readdirSync = spy;
     provision.read(fs as any);
 
-    chai.expect(spy).called.exactly(1);
+    chai.expect(spy).called.exactly(2);
   });
 
   let testfsMac1: any;


### PR DESCRIPTION
Xcode  16 downloads provisioning profiles to a new directory, this looks first for that directory and then in the previous directory.

Fixes issue: NativeScript/NativeScript#10633