### PR TITLE
fix: when process.env.HOME does not exist ( windows)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,15 @@
 	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 	"version": "0.2.0",
 	"configurations": [
+	{
+		"name": "Attach",
+		"port": 9229,
+		"request": "attach",
+		"skipFiles": [
+			"<node_internals>/**"
+		],
+		"type": "node"
+	},
 		{
 			"type": "node",
 			"request": "launch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,12 @@ import * as sec_find_cert from "./parsers/security-find-certificate";
 
 export namespace provision {
   const nodefs = { readdirSync, readFileSync };
-  const profileSources: string[] = [
+  const profileSources: string[] = (process && process.env && process.env.HOME) ? [
     join(process.env.HOME, "Library", "Developer", "Xcode", "UserData", "Provisioning Profiles"),
-    join(process.env.HOME, "Library/MobileDevice/Provisioning Profiles/")
-                                   ]
+    join(process.env.HOME, "Library/MobileDevice/Provisioning Profiles/")]:[];
+                                   
   const defaultPath: string[] = [];
-  if(process && process.env && process.env.HOME){
+  if(profileSources.length>0){
 
     profileSources.forEach(pDir => {
       if(existsSync(pDir)) {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -221,7 +221,17 @@ describe("security find-certificate parse", () => {
 
 describe("provision", function () {
   it("looks at the default path", () => {
-    let fs = {
+
+    let existingDirCount = 0;
+    
+    if(fs.existsSync(path.join(process.env.HOME, "/Library/MobileDevice/Provisioning Profiles/"))) {
+      existingDirCount++;
+    }
+    if(fs.existsSync(path.join(process.env.HOME,"/Library/Developer/Xcode/UserData/Provisioning Profiles"))) {
+      existingDirCount++;
+    }
+
+    let fsMock = {
       readdirSync(dir: string): string[] {
         assert(dir.endsWith("Library/MobileDevice/Provisioning Profiles/") ||
                dir.endsWith("Library/Developer/Xcode/UserData/Provisioning Profiles"));
@@ -231,11 +241,11 @@ describe("provision", function () {
         return null;
       },
     };
-    const spy = chai.spy(fs.readdirSync);
-    fs.readdirSync = spy;
-    provision.read(fs as any);
+    const spy = chai.spy(fsMock.readdirSync);
+    fsMock.readdirSync = spy;
+    provision.read(fsMock as any);
 
-    chai.expect(spy).called.exactly(2);
+    chai.expect(spy).called.exactly(existingDirCount);
   });
 
   let testfsMac1: any;


### PR DESCRIPTION
The previous PR #18 causes a crash on windows because HOME is not an environment variable  in windows.  This change protects against that.